### PR TITLE
fix: invalid WriteHeader code 0

### DIFF
--- a/jprq/messages.go
+++ b/jprq/messages.go
@@ -57,6 +57,9 @@ func (responseMessage ResponseMessage) WriteToHttpResponse(writer http.ResponseW
 	for name, value := range responseMessage.Header {
 		writer.Header().Set(name, value)
 	}
+	if 100 > responseMessage.Status || responseMessage.Status > 600 {
+		responseMessage.Status = http.StatusInternalServerError
+	}
 	writer.WriteHeader(responseMessage.Status)
 
 	decoded, err := base64.StdEncoding.DecodeString(responseMessage.Body)


### PR DESCRIPTION
# Fix: Invalid WriteHeader Code 0
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:2884 +0x2f4
Sep 10 08:02:42 jprq jprq.live[26819]: created by net/http.(*Server).Serve
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:1878 +0x851
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.(*conn).serve(0xc000571cc0, 0x7f6160, 0xc0009e0900)
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:2774 +0xa8
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.serverHandler.ServeHTTP(0xc00005cd00, 0x7f5a60, 0xc0011ca8c0, 0xc000f93300)
Sep 10 08:02:42 jprq jprq.live[26819]:         /Users/azimjon/go/src/github.com/gorilla/mux/mux.go:212 +0xe3
Sep 10 08:02:42 jprq jprq.live[26819]: github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000bc0c0, 0x7f5a60, 0xc0011ca8c0, 0xc000f93300)
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:1995 +0x44
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.HandlerFunc.ServeHTTP(0x79c3f0, 0x7f5a60, 0xc0011ca8c0, 0xc000f93f00)
Sep 10 08:02:42 jprq jprq.live[26819]:         /Users/azimjon/Projects/practice/jprq.live/jprq/http.go:21 +0x3de
Sep 10 08:02:42 jprq jprq.live[26819]: main.HttpHandler(0x7f5a60, 0xc0011ca8c0, 0xc000f93f00)
Sep 10 08:02:42 jprq jprq.live[26819]:         /Users/azimjon/Projects/practice/jprq.live/jprq/messages.go:60 +0x208
Sep 10 08:02:42 jprq jprq.live[26819]: main.ResponseMessage.WriteToHttpResponse(0xfe4a3fefe10c6249, 0xc5c2e5f56d4b1597, 0xc0012a5f40, 0x40, 0xc000f613c0, 0x1c, 0x0, 0xc000386180, 0x7f5
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:1127 +0x607
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.(*response).WriteHeader(0xc0011ca8c0, 0x0)
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:1093
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.checkWriteHeaderCode(...)
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/runtime/panic.go:522 +0x1b5
Sep 10 08:02:42 jprq jprq.live[26819]: panic(0x6ea0a0, 0xc000fb0a50)
Sep 10 08:02:42 jprq jprq.live[26819]:         /usr/local/Cellar/go/1.12.1/libexec/src/net/http/server.go:1769 +0x139
Sep 10 08:02:42 jprq jprq.live[26819]: net/http.(*conn).serve.func1(0xc000571cc0)
Sep 10 08:02:42 jprq jprq.live[26819]: goroutine 74410 [running]:
Sep 10 08:02:42 jprq jprq.live[26819]: 2020/09/10 08:02:42 http: panic serving 127.0.0.1:50702: invalid WriteHeader code 0
